### PR TITLE
always show dev btns when in dev mode

### DIFF
--- a/_includes/js/pageinit-js.html
+++ b/_includes/js/pageinit-js.html
@@ -67,10 +67,6 @@ function resetMetadata () {
     // reload
     location.reload();
 }
-/* show dev btns if metadata is changed */ 
-if (sessionStorage.getItem("cb_metadata_set")) { 
-    document.getElementById("cbSetUpDevBtns").classList.remove("d-none");
-}
 {% endif %}
 
 /* set base variables */

--- a/_includes/setup-modal.html
+++ b/_includes/setup-modal.html
@@ -1,5 +1,5 @@
 <!-- dev buttons -->
-<div id="cbSetUpDevBtns" class="d-none position-absolute top-0 end-0 p-3 bg-dark bg-opacity-75">
+<div id="cbSetUpDevBtns" class="position-absolute top-0 end-0 p-3 bg-dark bg-opacity-75">
     <button class="btn btn-sm btn-link text-white" onclick="refreshMetadata()" id="refreshButton">
         <svg class="bi icon-sprite" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
             <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>


### PR DESCRIPTION
@owikle this PR simplifies the dev btns (refresh + change metadata) by just having them always showing if `development-mode: true`. They are never hidden. (if development-mode is false, they don't exist)
If you think this makes more sense, please merge! May as well do it before teaching if it seems less confusing. 