### PR TITLE
remove "link to object" button on record if filename is blank

### DIFF
--- a/_includes/js/item-js.html
+++ b/_includes/js/item-js.html
@@ -6,6 +6,9 @@
 <script>
 /* function to find links to objects from filename field */ 
 function findFileLink(record) {
+    if (!record.filename) {
+        return "";
+    }
     var fileLink = record.filename.includes('/') ? record.filename : "{{ '/objects/' | relative_url }}" + record.filename;
     return fileLink;
 }


### PR DESCRIPTION
Not all metadata records with format "record" necessarily have values for filename. This removes the default link to filename if the value is blank.